### PR TITLE
Fixing Primal Destroyer Model

### DIFF
--- a/src/main/resources/assets/thaumicwonders/models/item/primal_destroyer.json
+++ b/src/main/resources/assets/thaumicwonders/models/item/primal_destroyer.json
@@ -1,5 +1,5 @@
 {
-    "parent": "item/generated",
+    "parent": "item/handheld",
     "textures": {
         "layer0": "thaumicwonders:items/primal_destroyer"
     }


### PR DESCRIPTION
The Primal Destroyer get the wrong model parent, as a tool, it's need to have handheld
(because the player worn it like a classic item instead of a tool)
![image](https://user-images.githubusercontent.com/25106146/59523692-3978b880-8ed2-11e9-86d1-2ac97c43ea1f.png)
