### PR TITLE
Fix Catalyzation Chamber  & Primordial Accretion Chamber duplication bugs

### DIFF
--- a/src/main/java/com/verdantartifice/thaumicwonders/common/blocks/devices/BlockCatalyzationChamber.java
+++ b/src/main/java/com/verdantartifice/thaumicwonders/common/blocks/devices/BlockCatalyzationChamber.java
@@ -123,9 +123,14 @@ public class BlockCatalyzationChamber extends BlockDeviceTW<TileCatalyzationCham
         if (!worldIn.isRemote && (entityIn.ticksExisted % 10 == 0)) {
             if (entityIn instanceof EntityItem) {
                 entityIn.motionY = 0.025D;
-                if (entityIn.onGround) {
+                if (entityIn.onGround && !entityIn.isDead) {
                     TileCatalyzationChamber tcc = (TileCatalyzationChamber)worldIn.getTileEntity(pos);
-                    ((EntityItem)entityIn).setItem(tcc.addItemsToInventory(((EntityItem)entityIn).getItem()));
+                    ItemStack remainder = tcc.addItemsToInventory(((EntityItem)entityIn).getItem());
+                    if(remainder != null && !remainder.isEmpty()) {
+                        ((EntityItem)entityIn).setItem(remainder);
+                    } else {
+                    	entityIn.setDead();
+                    }
                 }
             } else if (entityIn instanceof EntityLivingBase) {
                 ((EntityLivingBase)entityIn).addPotionEffect(new PotionEffect(MobEffects.POISON, 100));

--- a/src/main/java/com/verdantartifice/thaumicwonders/common/blocks/devices/BlockPrimordialAccretionChamber.java
+++ b/src/main/java/com/verdantartifice/thaumicwonders/common/blocks/devices/BlockPrimordialAccretionChamber.java
@@ -121,9 +121,14 @@ public class BlockPrimordialAccretionChamber extends BlockDeviceTW<TilePrimordia
         if (!worldIn.isRemote && (entityIn.ticksExisted % 10 == 0)) {
             if (entityIn instanceof EntityItem) {
                 entityIn.motionY = 0.025D;
-                if (entityIn.onGround) {
+                if (entityIn.onGround && !entityIn.isDead) {
                     TilePrimordialAccretionChamber tpac = (TilePrimordialAccretionChamber)worldIn.getTileEntity(pos);
-                    ((EntityItem)entityIn).setItem(tpac.addItemsToInventory(((EntityItem)entityIn).getItem()));
+                    ItemStack remainder = tpac.addItemsToInventory(((EntityItem)entityIn).getItem());
+                    if(remainder != null && !remainder.isEmpty()) {
+                        ((EntityItem)entityIn).setItem(remainder);
+                    } else {
+                    	entityIn.setDead();
+                    }
                 }
             } else if (entityIn instanceof EntityLivingBase) {
                 ((EntityLivingBase)entityIn).addPotionEffect(new PotionEffect(MobEffects.POISON, 100));


### PR DESCRIPTION
There's a duplication bug caused by improperly handling item pickups in the Catalyzation Chamber and Primordial Accretion Chamber (and the base Thaumcraft Infernal Furnace, too) that can be abused under specific subtick scenarios, this pull request fixes it in the Thaumic Wonders devices.

See TheCodex6824/ThaumcraftFix#28 if you want more information about the specifics, I had more time to go into more detail there.